### PR TITLE
Quote possible shell wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Ew, HTML. Let's run that through some pup selectors:
 
 ```bash
 $ curl http://www.pro-football-reference.com/years/2013/games.htm | \
-pup table#games a[href*=boxscores] attr{href}
+pup table#games 'a[href*=boxscores]' attr{href}
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Because of this:

```
$ echo a[href*=boxscores]
a[href*=boxscores]
$ touch ah
$ echo a[href*=boxscores]
ah
```
