### PR TITLE
Update deprecated hardware check

### DIFF
--- a/pup.rb
+++ b/pup.rb
@@ -4,7 +4,7 @@ class Pup < Formula
   homepage 'https://github.com/ericchiang/pup'
   version '0.4.0'
 
-  if Hardware.is_64_bit?
+  if Hardware::CPU.is_64_bit?
     url 'https://github.com/ericchiang/pup/releases/download/v0.4.0/pup_v0.4.0_darwin_amd64.zip'
     sha256 'c539a697efee2f8e56614a54cb3b215338e00de1f6a7c2fa93144ab6e1db8ebe'
   else


### PR DESCRIPTION
```plain
Warning: Calling Hardware.is_64_bit? is deprecated!
Use Hardware::CPU.is_64_bit? instead.
/Users/pair/Library/Caches/Homebrew/Formula/pup.rb:7:in `<class:Pup>'
```