### PR TITLE
Install through Homebrew without URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ If you have Go installed on your computer just run `go get`.
 
     go get github.com/ericchiang/pup
 
-If you're on OS X, use [Homebrew](http://brew.sh/) to install (no Go required).
+If you're on OS X (or Linux), use [Homebrew](http://brew.sh/) to install (no Go required).
 
-    brew install https://raw.githubusercontent.com/EricChiang/pup/master/pup.rb
+    brew install pup
 
 ## Quick start
 


### PR DESCRIPTION
Hi,

first of all: **THANKS FOR THIS GREAT TOOL** ❤️ 

### Now to the PR:

`pup` is available directly through `brew install pup`.

Homebrew is also available for Linux but using the URL fails in two ways:

1. Homebrew refuses to download the installer:

    ```txt
    $ brew install https://raw.githubusercontent.com/EricChiang/pup/master/pup.rb
    Traceback (most recent call last):
    `brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap on GitHub instead.: Invalid usage: Non-checksummed download of pup formula file from an arbitrary URL is unsupported!  (UsageError)
    `brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap on GitHub instead.: Invalid usage: Non-checksummed download of pup formula file from an arbitrary URL is unsupported!  (UsageError)
    ```

2. The Linux binaries are missing from the install script provided by the URL so
   even if you first download it manually, the installed binary is not for Linux