### PR TITLE
Update README to match required usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you have Go installed on your computer just run `go get`.
 
 If you're on OS X, use [Homebrew](http://brew.sh/) to install (no Go required).
 
-    brew install https://raw.githubusercontent.com/EricChiang/pup/master/pup.rb
+    brew install pup
 
 ## Quick start
 


### PR DESCRIPTION
Running the brew install command from the README yielded:
```
`brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap on GitHub instead.: Invalid usage: Non-checksummed download of pup formula file from an arbitrary URL is unsupported!  (UsageError)
`brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap on GitHub instead.: Invalid usage: Non-checksummed download of pup formula file from an arbitrary URL is unsupported!  (UsageError)
```

But the following command:
```
brew install pup
```

Worked perfectly.