### PR TITLE
Use actual pup brew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you have Go installed on your computer just run `go get`.
 
 If you're on OS X, use [Homebrew](http://brew.sh/) to install (no Go required).
 
-    brew install https://raw.githubusercontent.com/EricChiang/pup/master/pup.rb
+    brew install pup
 
 ## Quick start
 


### PR DESCRIPTION
This remote URL `brew install` was added to the README way back in acad6bb01c, and the formula was mainlined later, in https://github.com/Homebrew/homebrew-core/commit/687ba6f4ab8ead79c5937a80062d63c69e661f4f. Let's just use the real formula now – mostly so it's cleaner, but also so that Homebrew maintainers can issue build fixes independently of this repo :) 

Install succeeds:

```shell
$ brew install pup
==> Downloading https://ghcr.io/v2/homebrew/core/pup/manifests/0.4.0-2
==> Downloading https://ghcr.io/v2/homebrew/core/pup/blobs/sha256:b6854a47afc836d12ed5447f9d285484e200f0d4350411f5aac7bf5e30f33a07
==> Pouring pup--0.4.0.arm64_monterey.bottle.2.tar.gz
🍺  /opt/homebrew/Cellar/pup/0.4.0: 5 files, 3.7MB
==> Running `brew cleanup pup`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

$ pup --version
0.4.0
```

(ps big fan of this tool! thanks much!)