### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ fast and flexible way of exploring HTML from the terminal.
 
 Direct downloads are available through the [releases page](https://github.com/EricChiang/pup/releases/latest).
 
-If you have Go installed on your computer just run `go get`.
+If you have Go installed on your computer just run `go install`.
 
-    go get github.com/ericchiang/pup
+    go install github.com/ericchiang/pup@latest
 
 If you're on OS X, use [Homebrew](http://brew.sh/) to install (no Go required).
 


### PR DESCRIPTION
# Motivation
`go get` is now deprecated for installing executables.  See: https://go.dev/doc/go-get-install-deprecation

And indeed doesn't work any more.

# Changes
* Replace `go get` with the replacement `go install`

# Tests
Before:
```
max@sinkpad:~ (24)$ go get github.com/ericchiang/pup
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
max@sinkpad:~ (4:47)$ echo $?
1
```
After:
```
max@sinkpad:~ (43)$ go install github.com/ericchiang/pup@latest
go: finding module for package golang.org/x/text/transform
go: finding module for package golang.org/x/net/html/charset
go: finding module for package golang.org/x/net/html
go: finding module for package github.com/fatih/color
go: finding module for package golang.org/x/net/html/atom
go: finding module for package github.com/mattn/go-colorable
go: found github.com/fatih/color in github.com/fatih/color v1.15.0
go: found github.com/mattn/go-colorable in github.com/mattn/go-colorable v0.1.13
go: found golang.org/x/net/html in golang.org/x/net v0.8.0
go: found golang.org/x/net/html/atom in golang.org/x/net v0.8.0
go: found golang.org/x/net/html/charset in golang.org/x/net v0.8.0
go: found golang.org/x/text/transform in golang.org/x/text v0.8.0
max@sinkpad:~ (2:24)$ 
max@sinkpad:~ (5:13)$ echo $?
0
max@sinkpad:~ (5:15)$ which pup
/home/max/gopath/bin/pup
max@sinkpad:~ (5:24)$ 
```