### PR TITLE
Fix install via Go (use go install ... @latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ fast and flexible way of exploring HTML from the terminal.
 
 Direct downloads are available through the [releases page](https://github.com/EricChiang/pup/releases/latest).
 
-If you have Go installed on your computer just run `go get`.
+If you have Go installed on your computer just run `go install`.
 
-    go get github.com/ericchiang/pup
+    go install github.com/ericchiang/pup@latest
 
 If you're on OS X, use [Homebrew](http://brew.sh/) to install (no Go required).
 


### PR DESCRIPTION
go get is no longer the go install method, use `go install...` (see diff)