### PR TITLE
Go Install Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ If you're on OS X, use [Homebrew](http://brew.sh/) to install (no Go required).
 
 ## Quick start
 
+`pup` binary will be available at `~/go/bin/pup`
+
 ```bash
 $ curl -s https://news.ycombinator.com/
 ```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ fast and flexible way of exploring HTML from the terminal.
 
 Direct downloads are available through the [releases page](https://github.com/EricChiang/pup/releases/latest).
 
-If you have Go installed on your computer just run `go get`.
+If you have Go installed on your computer just run `go install`.
 
-    go get github.com/ericchiang/pup
+    go install github.com/ericchiang/pup@latest
 
 If you're on OS X, use [Homebrew](http://brew.sh/) to install (no Go required).
 


### PR DESCRIPTION
Replaced `go get` to `go install`.
`go get` has been deprecated since Go v1.17.
https://github.com/oauth2-proxy/oauth2-proxy/issues/2033